### PR TITLE
Fix 'undefined constant' warnings

### DIFF
--- a/action.php
+++ b/action.php
@@ -194,9 +194,9 @@ class action_plugin_odt2dw extends DokuWiki_Action_Plugin {
     if ( ! is_file($this->xslFile) ) return $this->_msg('er_xslFile_isfile');
 
     // Class Control
-    if ( ! class_exists( XSLTProcessor ) ) return $this->_msg('er_class_xsltProcessor');
-    if ( ! class_exists( ZipArchive ) ) return $this->_msg('er_class_zipArchive');
-    if ( ! class_exists( DOMDocument ) ) return $this->_msg('er_class_domDocument');
+    if ( ! class_exists( 'XSLTProcessor' ) ) return $this->_msg('er_class_xsltProcessor');
+    if ( ! class_exists( 'ZipArchive' ) ) return $this->_msg('er_class_zipArchive');
+    if ( ! class_exists( 'DOMDocument' ) ) return $this->_msg('er_class_domDocument');
     // Create instance of needed class
     $this->XSLT = new XSLTProcessor;
     $this->ZIP  = new ZipArchive;


### PR DESCRIPTION
Fixes the following warning messages:

```
Warning:  Use of undefined constant ZipArchive - assumed 'ZipArchive' (this will throw an Error in a future version of PHP) in /var/www/htdocs/kb/lib/plugins/odt2dw/action.php on line 198
Warning:  Use of undefined constant XSLTProcessor - assumed 'XSLTProcessor' (this will throw an Error in a future version of PHP) in /var/www/htdocs/kb/lib/plugins/odt2dw/action.php on line 197
Warning:  Use of undefined constant DOMDocument - assumed 'DOMDocument' (this will throw an Error in a future version of PHP) in /var/www/htdocs/kb/lib/plugins/odt2dw/action.php on line 199
```